### PR TITLE
Update types to reflect optional fields

### DIFF
--- a/packages/pagination/Pagination.astro
+++ b/packages/pagination/Pagination.astro
@@ -1,10 +1,10 @@
 ---
 export interface Props {
-  outerDiv: string;
+  outerDiv?: string;
   buttonGroup: string;
-  button: string;
-  activeButton: string;
-  disabledButton: string;
+  button?: string;
+  activeButton?: string;
+  disabledButton?: string;
   currentPage:Number;
   totalPage:Number;
   url:string;


### PR DESCRIPTION
I got some typing errors when running `astro check` complaining I was not passing some optional fields.

Since these fields are documented as optional and have a default value I just update the interface to reflect that.